### PR TITLE
Feat/swarinfo 324 send bytes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cmake-build-debug/
+cmake-build-debug-coverage/
 .idea/
 build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ set(header
         ${header_path}/ThreadSafeQueue.h
         ${header_path}/UserCallbackArgumentDescription.h
         ${header_path}/UserCallbackFunctionWrapper.h
+        ${header_path}/ByteSender.h
         )
 
 set(HIVEMIND_BRIDGE_SOURCES
@@ -53,7 +54,8 @@ set(HIVEMIND_BRIDGE_SOURCES
         src/UserCallbackArgumentDescription.cpp
         src/InboundRequestHandle.cpp
         src/InboundResponseHandle.cpp
-        src/OutboundRequestHandle.cpp)
+        src/OutboundRequestHandle.cpp
+        )
 
 add_library(${LIB_NAME} ${HIVEMIND_BRIDGE_SOURCES})
 add_library(${LIB_ALIAS} ALIAS ${LIB_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,6 @@ set(header
         ${header_path}/ThreadSafeQueue.h
         ${header_path}/UserCallbackArgumentDescription.h
         ${header_path}/UserCallbackFunctionWrapper.h
-        ${header_path}/ByteSender.h
         )
 
 set(HIVEMIND_BRIDGE_SOURCES

--- a/cmake/clang-tools/clang-format.cmake
+++ b/cmake/clang-tools/clang-format.cmake
@@ -1,6 +1,6 @@
 find_program(CLANG_FORMAT "clang-format")
 if(CLANG_FORMAT)
-    set(SOURCE_DIR ${PROJECT_SOURCE_DIR}/src)
+    set(SOURCE_DIR ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/include)
 
     add_custom_target(
         format

--- a/cmake/propolis/propolis.cmake
+++ b/cmake/propolis/propolis.cmake
@@ -11,7 +11,7 @@ function(propolis_fetch_populate)
             ${PROJECT_NAME}_propolis
 
             GIT_REPOSITORY https://github.com/SwarmUS/Propolis
-            GIT_TAG        3d3e0337c03126f78e0be8864f84f78e9e9215eb
+            GIT_TAG        4c3c369e8a1cd870ce5005bdd4f1b763fffd6d1e
             GIT_PROGRESS   TRUE
     )
 

--- a/include/HiveMindBridge/HiveMindBridge.h
+++ b/include/HiveMindBridge/HiveMindBridge.h
@@ -12,7 +12,7 @@
 #include <pheromones/HiveMindHostSerializer.h>
 
 class HiveMindBridge : public IHiveMindBridge {
-  public:
+public:
     /**
      * Construct a HiveMindBridge
      * @param tcpPort The port that the TCP server should listen to
@@ -35,7 +35,9 @@ class HiveMindBridge : public IHiveMindBridge {
 
     bool queueAndSend(MessageDTO message);
 
-  private:
+    bool sendBytes(uint32_t destinationId, const uint8_t* const payload, uint16_t payloadSize);
+
+private:
     ILogger& m_logger;
     TCPServer m_tcpServer;
     HiveMindHostDeserializer m_deserializer;

--- a/include/HiveMindBridge/HiveMindBridge.h
+++ b/include/HiveMindBridge/HiveMindBridge.h
@@ -12,7 +12,7 @@
 #include <pheromones/HiveMindHostSerializer.h>
 
 class HiveMindBridge : public IHiveMindBridge {
-public:
+  public:
     /**
      * Construct a HiveMindBridge
      * @param tcpPort The port that the TCP server should listen to
@@ -37,7 +37,7 @@ public:
 
     bool sendBytes(uint32_t destinationId, const uint8_t* const payload, uint16_t payloadSize);
 
-private:
+  private:
     ILogger& m_logger;
     TCPServer m_tcpServer;
     HiveMindHostDeserializer m_deserializer;

--- a/include/HiveMindBridge/HiveMindBridgeImpl.h
+++ b/include/HiveMindBridge/HiveMindBridgeImpl.h
@@ -8,15 +8,15 @@
 #include "HiveMindBridge/MessageHandler.h"
 #include "HiveMindBridge/OutboundRequestHandle.h"
 #include "HiveMindBridge/TCPServer.h"
+#include <cmath>
 #include <cpp-common/ILogger.h>
 #include <deque>
 #include <memory>
 #include <mutex>
+#include <pheromones/BytesDTO.h>
 #include <pheromones/HiveMindHostDeserializer.h>
 #include <pheromones/HiveMindHostSerializer.h>
-#include <pheromones/BytesDTO.h>
 #include <thread>
-#include <cmath>
 
 constexpr int THREAD_SLEEP_MS = 250; // The sleep time of the trheads
 constexpr int DELAY_BRFORE_DROP_S =

--- a/include/HiveMindBridge/HiveMindBridgeImpl.h
+++ b/include/HiveMindBridge/HiveMindBridgeImpl.h
@@ -14,7 +14,9 @@
 #include <mutex>
 #include <pheromones/HiveMindHostDeserializer.h>
 #include <pheromones/HiveMindHostSerializer.h>
+#include <pheromones/BytesDTO.h>
 #include <thread>
+#include <cmath>
 
 constexpr int THREAD_SLEEP_MS = 250; // The sleep time of the trheads
 constexpr int DELAY_BRFORE_DROP_S =
@@ -53,6 +55,8 @@ class HiveMindBridgeImpl : public IHiveMindBridge {
     bool registerCustomAction(std::string name, CallbackFunction callback) override;
 
     bool queueAndSend(MessageDTO message) override;
+
+    bool sendBytes(uint32_t destinationId, const uint8_t* const payload, uint16_t payloadSize);
 
     uint32_t getSwarmAgentId();
 

--- a/include/HiveMindBridge/IHiveMindBridge.h
+++ b/include/HiveMindBridge/IHiveMindBridge.h
@@ -59,6 +59,9 @@ class IHiveMindBridge {
      * @return true if the operation succeded.
      */
     virtual bool queueAndSend(MessageDTO message) = 0;
+
+    // Todo document
+    virtual bool sendBytes(uint32_t destinationId, const uint8_t* const payload, uint16_t payloadSize) = 0;
 };
 
 #endif // HIVEMIND_BRIDGE_IHIVEMINDBRIDGE_H

--- a/include/HiveMindBridge/IHiveMindBridge.h
+++ b/include/HiveMindBridge/IHiveMindBridge.h
@@ -60,7 +60,13 @@ class IHiveMindBridge {
      */
     virtual bool queueAndSend(MessageDTO message) = 0;
 
-    // Todo document
+    /**
+     * Send an array of bytes asynchronously
+     * @param destinationId The Agent to which the data is to be sent
+     * @param payload An array of bytes
+     * @param payloadSize The length of the array of bytes
+     * @return
+     */
     virtual bool sendBytes(uint32_t destinationId, const uint8_t* const payload, uint16_t payloadSize) = 0;
 };
 

--- a/include/HiveMindBridge/IHiveMindBridge.h
+++ b/include/HiveMindBridge/IHiveMindBridge.h
@@ -67,7 +67,9 @@ class IHiveMindBridge {
      * @param payloadSize The length of the array of bytes
      * @return
      */
-    virtual bool sendBytes(uint32_t destinationId, const uint8_t* const payload, uint16_t payloadSize) = 0;
+    virtual bool sendBytes(uint32_t destinationId,
+                           const uint8_t* const payload,
+                           uint16_t payloadSize) = 0;
 };
 
 #endif // HIVEMIND_BRIDGE_IHIVEMINDBRIDGE_H

--- a/include/HiveMindBridge/IMessageHandler.h
+++ b/include/HiveMindBridge/IMessageHandler.h
@@ -1,9 +1,9 @@
 #ifndef HIVEMIND_BRIDGE_IMESSAGEHANDLER_H
 #define HIVEMIND_BRIDGE_IMESSAGEHANDLER_H
 
-#include "InboundRequestHandle.h"
 #include "HiveMindBridge/InboundResponseHandle.h"
 #include "HiveMindBridge/UserCallbackFunctionWrapper.h"
+#include "InboundRequestHandle.h"
 #include <optional>
 #include <pheromones/FunctionCallArgumentDTO.h>
 #include <pheromones/FunctionCallRequestDTO.h>

--- a/include/HiveMindBridge/MessageHandler.h
+++ b/include/HiveMindBridge/MessageHandler.h
@@ -2,8 +2,8 @@
 #define HIVE_MIND_BRIDGE_MESSAGEHANDLER_H
 
 #include "Callback.h"
-#include "IMessageHandler.h"
 #include "HiveMindBridge/MessageUtils.h"
+#include "IMessageHandler.h"
 #include <cpp-common/ILogger.h>
 
 class MessageHandler : public IMessageHandler {

--- a/include/HiveMindBridge/MessageUtils.h
+++ b/include/HiveMindBridge/MessageUtils.h
@@ -103,14 +103,14 @@ namespace MessageUtils {
      * @param payloadLength The length of the payload that constitutes this packet
      * @return
      */
-    MessageDTO createBytesMessage(uint32_t msgSourceId,
-                                  uint32_t msgDestinationId,
-                                  uint32_t requestId,
-                                  uint32_t byteReqId,
-                                  uint32_t packetNumber,
-                                  bool lastPacket,
-                                  uint8_t* payload,
-                                  uint16_t payloadLength);
+    std::optional<MessageDTO> createBytesMessage(uint32_t msgSourceId,
+                                                 uint32_t msgDestinationId,
+                                                 uint32_t requestId,
+                                                 uint32_t byteReqId,
+                                                 uint32_t packetNumber,
+                                                 bool lastPacket,
+                                                 uint8_t* payload,
+                                                 uint16_t payloadLength);
 
     /**
      * Create a greet message

--- a/include/HiveMindBridge/MessageUtils.h
+++ b/include/HiveMindBridge/MessageUtils.h
@@ -90,7 +90,19 @@ namespace MessageUtils {
                                          UserCallTargetDTO moduleDestination,
                                          std::string callbackName);
 
-    // TODO document
+    /**
+     * Create a message with a Bytes request. This only creates the message, and does NOT manage
+     * the packet numbering logic.
+     * @param msgSourceId The ID of this device
+     * @param msgDestinationId The ID of the target device
+     * @param requestId The ID of the request
+     * @param byteReqId The ID of the Bytes request
+     * @param packetNumber The number of this packet
+     * @param lastPacket Whether this is the last packet in the Bytes request
+     * @param payload The section of the payload that constitutes this packet
+     * @param payloadLength The length of the payload that constitutes this packet
+     * @return
+     */
     MessageDTO createBytesMessage(uint32_t msgSourceId,
                                   uint32_t msgDestinationId,
                                   uint32_t requestId,

--- a/include/HiveMindBridge/MessageUtils.h
+++ b/include/HiveMindBridge/MessageUtils.h
@@ -90,6 +90,16 @@ namespace MessageUtils {
                                          UserCallTargetDTO moduleDestination,
                                          std::string callbackName);
 
+    // TODO document
+    MessageDTO createBytesMessage(uint32_t msgSourceId,
+                                  uint32_t msgDestinationId,
+                                  uint32_t requestId,
+                                  uint32_t byteReqId,
+                                  uint32_t packetNumber,
+                                  bool lastPacket,
+                                  uint8_t* payload,
+                                  uint16_t payloadLength);
+
     /**
      * Create a greet message
      * @return The created message

--- a/src/HiveMindBridge.cpp
+++ b/src/HiveMindBridge.cpp
@@ -34,6 +34,8 @@ bool HiveMindBridge::registerCustomAction(std::string name, CallbackFunction cal
 
 bool HiveMindBridge::queueAndSend(MessageDTO message) { return m_bridge.queueAndSend(message); }
 
-bool HiveMindBridge::sendBytes(uint32_t destinationId, const uint8_t* const payload, uint16_t payloadSize) {
+bool HiveMindBridge::sendBytes(uint32_t destinationId,
+                               const uint8_t* const payload,
+                               uint16_t payloadSize) {
     return m_bridge.sendBytes(destinationId, payload, payloadSize);
 }

--- a/src/HiveMindBridge.cpp
+++ b/src/HiveMindBridge.cpp
@@ -33,3 +33,7 @@ bool HiveMindBridge::registerCustomAction(std::string name, CallbackFunction cal
 }
 
 bool HiveMindBridge::queueAndSend(MessageDTO message) { return m_bridge.queueAndSend(message); }
+
+bool HiveMindBridge::sendBytes(uint32_t destinationId, const uint8_t* const payload, uint16_t payloadSize) {
+    return m_bridge.sendBytes(destinationId, payload, payloadSize);
+}

--- a/src/HiveMindBridgeImpl.cpp
+++ b/src/HiveMindBridgeImpl.cpp
@@ -7,13 +7,13 @@ HiveMindBridgeImpl::HiveMindBridgeImpl(ITCPServer& tcpServer,
                                        IThreadSafeQueue<MessageDTO>& inboundQueue,
                                        IThreadSafeQueue<OutboundRequestHandle>& outboundQueue,
                                        ILogger& logger) :
-        m_tcpServer(tcpServer),
-        m_serializer(serializer),
-        m_deserializer(deserializer),
-        m_messageHandler(messageHandler),
-        m_inboundQueue(inboundQueue),
-        m_outboundQueue(outboundQueue),
-        m_logger(logger) {}
+    m_tcpServer(tcpServer),
+    m_serializer(serializer),
+    m_deserializer(deserializer),
+    m_messageHandler(messageHandler),
+    m_inboundQueue(inboundQueue),
+    m_outboundQueue(outboundQueue),
+    m_logger(logger) {}
 
 HiveMindBridgeImpl::~HiveMindBridgeImpl() {
     m_tcpServer.close();
@@ -106,8 +106,10 @@ bool HiveMindBridgeImpl::queueAndSend(MessageDTO message) {
     return false;
 }
 
-bool HiveMindBridgeImpl::sendBytes(uint32_t destinationId, const uint8_t* const payload, uint16_t payloadSize) {
-    int nPackets = std::ceil((float) payloadSize / BYTES_PAYLOAD_SIZE);
+bool HiveMindBridgeImpl::sendBytes(uint32_t destinationId,
+                                   const uint8_t* const payload,
+                                   uint16_t payloadSize) {
+    int nPackets = std::ceil((float)payloadSize / BYTES_PAYLOAD_SIZE);
     uint32_t bytesReqId = MessageUtils::generateRandomId();
 
     for (int packetNumber = 0; packetNumber < nPackets; packetNumber++) {
@@ -120,18 +122,15 @@ bool HiveMindBridgeImpl::sendBytes(uint32_t destinationId, const uint8_t* const 
             packetSize = (payloadSize - packetNumber * BYTES_PAYLOAD_SIZE) % BYTES_PAYLOAD_SIZE;
         }
 
-        uint8_t* packetStartPtr = (uint8_t*) payload + packetStartIndex;
+        uint8_t* packetStartPtr = (uint8_t*)payload + packetStartIndex;
 
-        MessageDTO msg = MessageUtils::createBytesMessage(m_swarmAgentID,
-                                                          destinationId,
-                                                          MessageUtils::generateRandomId(),
-                                                          bytesReqId,
-                                                          packetNumber,
-                                                          isLastPacket,
-                                                          packetStartPtr,
-                                                          packetSize);
+        MessageDTO msg = MessageUtils::createBytesMessage(
+            m_swarmAgentID, destinationId, MessageUtils::generateRandomId(), bytesReqId,
+            packetNumber, isLastPacket, packetStartPtr, packetSize);
 
-        if (!queueAndSend(msg)) { return false; }
+        if (!queueAndSend(msg)) {
+            return false;
+        }
     }
 
     return true;
@@ -208,12 +207,12 @@ void HiveMindBridgeImpl::sendReturn(InboundRequestHandle result) {
     if (callbackReturnOpt.has_value()) {
         CallbackArgs args = callbackReturnOpt.value().getReturnArgs();
         MessageDTO returnMessage = MessageUtils::createFunctionCallRequest(
-                result.getMessageDestinationId(), // swap source and dest since we
-                // return to the sender
-                result.getMessageSourceId(), MessageUtils::generateRandomId(),
-                result.getSourceModule(), // swap source and dest since we return to the
-                // sender
-                callbackReturnOpt.value().getReturnFunctionName(), args);
+            result.getMessageDestinationId(), // swap source and dest since we
+            // return to the sender
+            result.getMessageSourceId(), MessageUtils::generateRandomId(),
+            result.getSourceModule(), // swap source and dest since we return to the
+            // sender
+            callbackReturnOpt.value().getReturnFunctionName(), args);
 
         m_serializer.serializeToStream(returnMessage);
     }

--- a/src/HiveMindBridgeImpl.cpp
+++ b/src/HiveMindBridgeImpl.cpp
@@ -166,7 +166,7 @@ void HiveMindBridgeImpl::outboundThread() {
                     // TODO add some retry logic in case the response was not ok
                     m_outboundQueue.pop();
                     m_inboundResponsesMap.erase(search);
-                    m_logger.log(LogLevel::Info, "RECEIVED VALID RESPONSE");
+                    m_logger.log(LogLevel::Debug, "RECEIVED VALID RESPONSE");
                 } else {
                     // Did not receive a response for this request. Was the request sent?
                     if (handle.getState() == OutboundRequestState::READY) {

--- a/src/MessageUtils.cpp
+++ b/src/MessageUtils.cpp
@@ -79,14 +79,18 @@ MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
     return message;
 }
 
-MessageDTO MessageUtils::createBytesMessage(uint32_t msgSourceId,
-                                            uint32_t msgDestinationId,
-                                            uint32_t requestId,
-                                            uint32_t byteReqId,
-                                            uint32_t packetNumber,
-                                            bool lastPacket,
-                                            uint8_t* payload,
-                                            uint16_t payloadLength) {
+std::optional<MessageDTO> MessageUtils::createBytesMessage(uint32_t msgSourceId,
+                                                           uint32_t msgDestinationId,
+                                                           uint32_t requestId,
+                                                           uint32_t byteReqId,
+                                                           uint32_t packetNumber,
+                                                           bool lastPacket,
+                                                           uint8_t* payload,
+                                                           uint16_t payloadLength) {
+    if (payloadLength > BytesDTO::PAYLOAD_MAX_SIZE) {
+        return {};
+    }
+
     BytesDTO bytes(byteReqId, packetNumber, lastPacket, payload, payloadLength);
     HiveMindHostApiRequestDTO hmReq(bytes);
     RequestDTO req(requestId, hmReq);

--- a/src/MessageUtils.cpp
+++ b/src/MessageUtils.cpp
@@ -80,13 +80,13 @@ MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
 }
 
 MessageDTO MessageUtils::createBytesMessage(uint32_t msgSourceId,
-                              uint32_t msgDestinationId,
-                              uint32_t requestId,
-                              uint32_t byteReqId,
-                              uint32_t packetNumber,
-                              bool lastPacket,
-                              uint8_t* payload,
-                              uint16_t payloadLength) {
+                                            uint32_t msgDestinationId,
+                                            uint32_t requestId,
+                                            uint32_t byteReqId,
+                                            uint32_t packetNumber,
+                                            bool lastPacket,
+                                            uint8_t* payload,
+                                            uint16_t payloadLength) {
     BytesDTO bytes(byteReqId, packetNumber, lastPacket, payload, payloadLength);
     HiveMindHostApiRequestDTO hmReq(bytes);
     RequestDTO req(requestId, hmReq);

--- a/src/MessageUtils.cpp
+++ b/src/MessageUtils.cpp
@@ -79,6 +79,20 @@ MessageDTO MessageUtils::createFunctionCallRequest(uint32_t msgSourceId,
     return message;
 }
 
+MessageDTO MessageUtils::createBytesMessage(uint32_t msgSourceId,
+                              uint32_t msgDestinationId,
+                              uint32_t requestId,
+                              uint32_t byteReqId,
+                              uint32_t packetNumber,
+                              bool lastPacket,
+                              uint8_t* payload,
+                              uint16_t payloadLength) {
+    BytesDTO bytes(byteReqId, packetNumber, lastPacket, payload, payloadLength);
+    HiveMindHostApiRequestDTO hmReq(bytes);
+    RequestDTO req(requestId, hmReq);
+    return MessageDTO(msgSourceId, msgDestinationId, req);
+}
+
 MessageDTO MessageUtils::createGreetMessage() { return MessageDTO(0, 0, GreetingDTO(0)); }
 
 uint32_t MessageUtils::generateRandomId() { return rand() % UINT32_MAX; }

--- a/test/integration/SendRequestIntegrationTest.cpp
+++ b/test/integration/SendRequestIntegrationTest.cpp
@@ -94,6 +94,7 @@ public:
             bytesReqId = bytes.getPacketId();
 
             ASSERT_EQ(bytes.getPacketNumber(), 0);
+            ASSERT_FALSE(bytes.isLastPacket());
         }
 
         // Check packets in the middle
@@ -102,6 +103,7 @@ public:
 
             ASSERT_EQ(bytes.getPacketNumber(), i);
             ASSERT_EQ(bytes.getPacketId(), bytesReqId);
+            ASSERT_FALSE(bytes.isLastPacket());
         }
 
         // Check last packet

--- a/test/integration/UserCallbackIntegrationTest.cpp
+++ b/test/integration/UserCallbackIntegrationTest.cpp
@@ -156,46 +156,7 @@ public:
 
         cleanUpAfterTest();
     }
-
-    void testSpamFunctionCalls() {
-        // Given
-        FunctionCallArgumentDTO x((int64_t ) 1);
-        FunctionCallArgumentDTO y((int64_t ) 1);
-        FunctionCallArgumentDTO args[] = {x, y};
-
-        FunctionCallRequestDTO functionCallRequest("sideEffect", args, 2);
-        UserCallRequestDTO ucReq(UserCallTargetDTO::BUZZ, UserCallTargetDTO::HOST, functionCallRequest);
-        RequestDTO req(865, ucReq);
-        MessageDTO reqMsg(CLIENT_AGENT_ID, CLIENT_AGENT_ID, req);
-
-        // When
-        for (int i = 0; i < 100; i++) {
-            m_clientSerializer->serializeToStream(reqMsg);
-        }
-
-        std::this_thread::sleep_for(std::chrono::milliseconds(101*THREAD_DELAY_MS));
-
-        MessageDTO responseMessage;
-        m_clientDeserializer->deserializeFromStream(responseMessage);
-
-        // Then
-        auto response = std::get<ResponseDTO>(responseMessage.getMessage());
-        auto userCallResponse = std::get<UserCallResponseDTO>(response.getResponse());
-        auto functionCallResponse = std::get<FunctionCallResponseDTO>(userCallResponse.getResponse());
-        GenericResponseStatusDTO status = functionCallResponse.getResponse().getStatus();
-
-        // Check response message
-        ASSERT_EQ(response.getId(), 865);
-        ASSERT_EQ(userCallResponse.getDestination(), UserCallTargetDTO::BUZZ);
-        ASSERT_EQ(status, GenericResponseStatusDTO::Ok);
-
-        // Check that the function was called (side-effects)
-        ASSERT_EQ(g_posX, 100);
-        ASSERT_EQ(g_posY, 100);
-
-        cleanUpAfterTest();
-    }
-
+    
     void testGetInstantaneousPayload() {
         // Given
         FunctionCallRequestDTO functionCallRequest("getInstantaneousPayload", nullptr, 0);
@@ -287,9 +248,6 @@ TEST_F(UserCallbackIntegrationTestFixture, testUserCallbacks) {
     // sideEffect callback that edits two values
     testSideEffectSuccess();
     testSideEffectFail();
-
-    // stress test
-    //testSpamFunctionCalls();
 
     // getInstantaneousPayload (payload return)
     testGetInstantaneousPayload();

--- a/test/utils/BytesTestData.h
+++ b/test/utils/BytesTestData.h
@@ -11,10 +11,10 @@ struct ByteArray{
     }
 };
 
-constexpr uint8_t SMALL_BYTE_ARRAY_SIZE = 8;
+constexpr int SMALL_BYTE_ARRAY_SIZE = 8;
 constexpr ByteArray SMALL_BYTE_ARRAY = ByteArray<SMALL_BYTE_ARRAY_SIZE>();
 
-constexpr uint8_t LONG_BYTE_ARRAY_SIZE = 1024;
+constexpr int LONG_BYTE_ARRAY_SIZE = 1024;
 constexpr ByteArray LONG_BYTE_ARRAY = ByteArray<LONG_BYTE_ARRAY_SIZE>();
 
 #endif //HIVEMINDBRIDGE_BYTESTESTDATA_H

--- a/test/utils/BytesTestData.h
+++ b/test/utils/BytesTestData.h
@@ -1,0 +1,20 @@
+#ifndef HIVEMINDBRIDGE_BYTESTESTDATA_H
+#define HIVEMINDBRIDGE_BYTESTESTDATA_H
+
+template<int size>
+struct ByteArray{
+    uint8_t arr[size];
+
+    constexpr ByteArray():arr(){
+        for(int i = 0; i < size; i++) // will cycle through values from 0 to 255 since uint8
+            arr[i] = i;
+    }
+};
+
+constexpr uint8_t SMALL_BYTE_ARRAY_SIZE = 8;
+constexpr ByteArray SMALL_BYTE_ARRAY = ByteArray<SMALL_BYTE_ARRAY_SIZE>();
+
+constexpr uint8_t LONG_BYTE_ARRAY_SIZE = 1024;
+constexpr ByteArray LONG_BYTE_ARRAY = ByteArray<LONG_BYTE_ARRAY_SIZE>();
+
+#endif //HIVEMINDBRIDGE_BYTESTESTDATA_H

--- a/test/utils/HiveMindBridgeFixture.h
+++ b/test/utils/HiveMindBridgeFixture.h
@@ -15,7 +15,7 @@
 std::atomic_bool g_threadShouldRun = true;
 
 constexpr uint32_t CLIENT_AGENT_ID = 12;
-constexpr int THREAD_DELAY_MS = 100;
+constexpr int THREAD_DELAY_MS = 10;
 
 class HiveMindBridgeFixture {
 protected:


### PR DESCRIPTION
A new `sendBytes()` method is exposed to the user in `HiveMindBridge` class. This method takes an array of bytes and manages the separation in packets.